### PR TITLE
Fix Create package is some edge cases

### DIFF
--- a/src/main/java/ch/nerdin/esbuild/Bundler.java
+++ b/src/main/java/ch/nerdin/esbuild/Bundler.java
@@ -88,11 +88,12 @@ public class Bundler {
         }
 
         for (Path path : dependencies) {
-            UnZip.unzip(path, bundleDirectory);
             final NameVersion nameVersion = parseName(path.getFileName().toString());
+            final Path temp = Files.createTempDirectory(nameVersion.toString());
+            UnZip.unzip(path, temp);
             switch (type) {
-                case MVNPM -> ImportToPackage.createPackage(bundleDirectory, nameVersion.name, nameVersion.version);
-                case WEBJARS -> Files.move(bundleDirectory.resolve(WEBJAR_PACKAGE_PREFIX).resolve(nameVersion.name)
+                case MVNPM -> ImportToPackage.createPackage(nodeModules, temp, nameVersion.name, nameVersion.version);
+                case WEBJARS -> Files.move(temp.resolve(WEBJAR_PACKAGE_PREFIX).resolve(nameVersion.name)
                         .resolve(nameVersion.version), nodeModules.resolve(nameVersion.name));
             }
         }
@@ -126,6 +127,11 @@ public class Bundler {
         public NameVersion(String name, String version) {
             this.name = name;
             this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder().append(name).append("-").append(version).toString();
         }
     }
 }

--- a/src/main/java/ch/nerdin/esbuild/util/ImportToPackage.java
+++ b/src/main/java/ch/nerdin/esbuild/util/ImportToPackage.java
@@ -40,8 +40,12 @@ public class ImportToPackage {
         }
     }
 
-    public static void createPackage(Path location, String moduleName, String version) throws IOException {
+    public static void createPackage(Path nodeModules, Path location, String moduleName, String version) throws IOException {
         final Path importMapFile = location.resolve(IMPORT_FILE_NAME);
+        if(!Files.isRegularFile(importMapFile)) {
+            // This is not a valid MVNPM dependency
+            return;
+        }
         final String[] result = extractInfo(importMapFile);
         final String name = result[0];
         final String packageContents = convert(name, version,  result[1].substring( result[1].indexOf(name) + name.length() + 1));
@@ -52,10 +56,9 @@ public class ImportToPackage {
 
         Files.writeString(packageFile, packageContents);
 
-        final Path nodeModules = location.resolve("node_modules").resolve(name);
-        final File parent = nodeModules.getParent().toFile();
         // in case there is a / in the name
-        if (!parent.exists()) parent.mkdirs();
-        Files.move(packageFile.getParent(), nodeModules);
+        if (!Files.exists(nodeModules)) Files.createDirectories(nodeModules);
+        Files.move(packageFile.getParent(), nodeModules.resolve(name));
+
     }
 }


### PR DESCRIPTION
- Use a temp directory when unzipping jars to allow easier debugging and avoid "polluting" the bundle directory
- Ignore the directory if it's not following the mvnpm impormap structure